### PR TITLE
[6237] Rename site title to Passport ONESIAM

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <%= stylesheet_link_tag "application" %>
     <%= csrf_meta_tags %>
-    <title>Passport</title>
+    <title>Passport ONESIAM</title>
   </head>
   <body>
     <div class="container-fluid">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <%= stylesheet_link_tag "application" %>
     <%= csrf_meta_tags %>
-    <title>Passport 1112</title>
+    <title>Passport</title>
   </head>
   <body>
     <div class="container-fluid">


### PR DESCRIPTION
https://app.clubhouse.io/loyalty-demo/story/6237/change-the-application-title-in-doorkeeper-provider-app-from-passport-1112-to-passport

## What happened 👀

Rename the title of the tab from `Passport 1112` to `Passport ONESIAM`.
 
## Insight 📝

N/A

## Proof Of Work 📹

![Screen Shot 2021-02-05 at 10 54 32 AM](https://user-images.githubusercontent.com/948856/106987663-8cd30500-67a0-11eb-9475-ccc798f7d1e7.png)
